### PR TITLE
fix: include dev deps for tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "npm": "9.x"
   },
   "scripts": {
-    "heroku-postbuild": "cd frontend && npm ci && npm run build"
+    "heroku-postbuild": "cd frontend && npm ci --include=dev && npm run build"
   }
 }


### PR DESCRIPTION
## What

Fixes Heroku build failure by explicitly including `devDependencies` during `npm ci` installation, ensuring TypeScript compiler and Vite are available even when `NODE_ENV=production` is set by Heroku.

## Why

Heroku automatically sets `NODE_ENV=production` during builds, which causes npm to skip installing `devDependencies` by default. This resulted in build failures because:

- TypeScript compiler (`tsc`) is in `devDependencies` but required for `npm run build`
- Vite build tool is in `devDependencies` but required for bundling
- Build script `tsc && vite build` fails with `command not found` errors

**Root Cause:**
When `NODE_ENV=production` is set (which Heroku does automatically), npm's default behavior is to skip `devDependencies` to optimize production builds. However, our build process requires these dev dependencies because:
- The build step (`npm run build`) executes `tsc && vite build`
- Both `typescript` and `vite` packages are in `devDependencies`
- These tools are needed at build time, not runtime

**Impact:**
- Heroku builds fail during the `heroku-postbuild` step
- Frontend cannot be compiled and deployed
- Production application remains unavailable

## How

### Solution: Add `--include=dev` Flag to npm ci

**Before:**
```json
"heroku-postbuild": "cd frontend && npm ci && npm run build"
```

**After:**
```json
"heroku-postbuild": "cd frontend && npm ci --include=dev && npm run build"
```

## Acceptance Criteria

- [x] Heroku build succeeds even with `NODE_ENV=production`
- [x] `devDependencies` are installed during build
- [x] TypeScript compilation succeeds (`tsc` command available)
- [x] Vite build succeeds (`vite build` command available)
- [x] Frontend `dist/` directory is created
- [x] All CI checks pass
- [x] Production deployment works correctly

## Testing

- ✅ Heroku build completes successfully
- ✅ TypeScript compiler available during build
- ✅ Vite build tool available during build
- ✅ Frontend builds correctly
- ✅ Production bundle generated in `frontend/dist/`

Closes #37