### PR TITLE
fix: Add psycopg2 for PostgreSQL and Enable Demo Mode

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,4 +26,5 @@ radon>=6.0.0
 
 # Production Server
 gunicorn==21.2.0
+psycopg2-binary==2.9.9
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "npm": "9.x"
   },
   "scripts": {
-    "heroku-postbuild": "cd frontend && npm ci --include=dev && npm run build"
+    "heroku-postbuild": "cd frontend && npm ci --include=dev && VITE_DEMO_MODE=true npm run build"
   }
 }


### PR DESCRIPTION
### What

Fixes Heroku deployment by adding PostgreSQL database driver (`psycopg2-binary`) to requirements and enabling demo mode in the frontend build process.

### Why

**Problem 1: Missing PostgreSQL Driver**
Heroku uses PostgreSQL as the production database, but the application was missing the required database driver. When the Flask application tried to connect to PostgreSQL, it failed with:


**Problem 2: Demo Mode Not Enabled**
The frontend build process wasn't setting the `VITE_DEMO_MODE` environment variable, causing demo mode features to be unavailable in production. This prevented users from accessing demo login functionality.

**Root Causes:**
1. **Missing psycopg2-binary**: SQLAlchemy requires a database driver to connect to PostgreSQL. While the code was configured to use PostgreSQL on Heroku, the driver package wasn't installed.
2. **Demo mode not set at build time**: Vite environment variables must be set during the build process. Without `VITE_DEMO_MODE=true` during `npm run build`, the demo mode toggle wouldn't appear in production.

**Impact:**
- Backend cannot connect to Heroku PostgreSQL database
- Application crashes on startup
- Demo mode unavailable in production
- Users cannot test the application without Google OAuth setup

### How

#### Solution 1: Add psycopg2-binary to requirements.txt

**File:** `backend/requirements.txt`

**Added:**

**What psycopg2-binary does:**
- Provides PostgreSQL database adapter for Python
- Required by SQLAlchemy to connect to PostgreSQL databases
- `-binary` version includes pre-compiled binaries (no compilation needed)
- Faster installation and more reliable on Heroku's build environment

#### Solution 2: Enable Demo Mode in Frontend Build

**File:** `package.json` (root)

**Updated heroku-postbuild script:**
```json
"heroku-postbuild": "cd frontend && npm ci --include=dev && VITE_DEMO_MODE=true npm run build"
```

**What this does:**
- Sets `VITE_DEMO_MODE=true` environment variable during build
- Vite injects this value into the built application
- Demo mode toggle becomes available in production
- Users can test the application without OAuth setup

### Build Process After Fix

1. **Python Dependencies:**
   - Heroku installs Python dependencies from `requirements.txt`
   - `psycopg2-binary==2.9.9` is installed
   - Flask application can connect to PostgreSQL



### Acceptance Criteria

- [x] `psycopg2-binary` added to `backend/requirements.txt`
- [x] PostgreSQL database connection works on Heroku
- [x] `VITE_DEMO_MODE=true` set in `heroku-postbuild` script
- [x] Demo mode toggle visible in production
- [x] Backend starts successfully on Heroku
- [x] Frontend builds with demo mode enabled
- [x] All CI checks pass
- [x] Production deployment succeeds

### Testing

- ✅ PostgreSQL connection successful on Heroku
- ✅ Demo mode toggle appears in production login page
- ✅ Demo login functionality works
- ✅ Backend application starts without errors
- ✅ All dependencies install correctly

Closes #39