### PR TITLE
fix: Profile Picture URLs Not Working on Heroku

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -382,13 +382,7 @@ const AppShell: React.FC<AppShellProps> = ({ children, pageTitle }) => {
                   name={user?.name || 'User'}
                   email={user?.email}
                   userId={user?.id}
-                  profilePhotoUrl={
-                    user?.profile_picture_url
-                      ? user.profile_picture_url.startsWith('http')
-                        ? user.profile_picture_url
-                        : `http://localhost:5000${user.profile_picture_url}`
-                      : undefined
-                  }
+                  profilePhotoUrl={user?.profile_picture_url || undefined}
                   size="md"
                 />
               </Dropdown.Toggle>

--- a/frontend/src/components/ProfileEditModal.tsx
+++ b/frontend/src/components/ProfileEditModal.tsx
@@ -31,10 +31,7 @@ const ProfileEditModal: React.FC<ProfileEditModalProps> = ({ show, onHide, user,
       setRemovePicture(false);
       // Set preview to existing profile picture if available
       if (user.profile_picture_url) {
-        const fullUrl = user.profile_picture_url.startsWith('http')
-          ? user.profile_picture_url
-          : `http://localhost:5000${user.profile_picture_url}`;
-        setPreviewUrl(fullUrl);
+        setPreviewUrl(user.profile_picture_url);
       } else {
         setPreviewUrl(null);
       }

--- a/frontend/src/components/ShiftScheduleGrid.tsx
+++ b/frontend/src/components/ShiftScheduleGrid.tsx
@@ -77,13 +77,7 @@ const DraggableWorker: React.FC<{
       <UserAvatar
         name={user.name}
         userId={user.id}
-        profilePhotoUrl={
-          user.profile_picture_url
-            ? user.profile_picture_url.startsWith('http')
-              ? user.profile_picture_url
-              : `http://localhost:5000${user.profile_picture_url}`
-            : undefined
-        }
+        profilePhotoUrl={user.profile_picture_url || undefined}
         size="sm"
         showBorder={false}
       />
@@ -119,13 +113,7 @@ const ShiftBlock: React.FC<{
         <UserAvatar
           name={user?.name || '?'}
           userId={assignment.user_id}
-          profilePhotoUrl={
-            user?.profile_picture_url
-              ? user.profile_picture_url.startsWith('http')
-                ? user.profile_picture_url
-                : `http://localhost:5000${user.profile_picture_url}`
-              : undefined
-          }
+          profilePhotoUrl={user?.profile_picture_url || undefined}
           size="xs"
           showBorder={false}
         />


### PR DESCRIPTION
## Pull Request Description

### What

Fixes profile picture display by removing hardcoded `http://localhost:5000` URLs and using relative URLs instead, enabling profile pictures to work correctly in both development and production environments.

### Why

**Problem: Profile Pictures Not Loading on Heroku**

Profile pictures fail to load on Heroku because the frontend hardcodes `http://localhost:5000` when constructing profile picture URLs. This causes images to fail loading in production where the backend URL is different.

**Root Cause:**
- Multiple frontend components hardcode `http://localhost:5000` when building profile picture URLs
- On Heroku, the backend URL is different (e.g., `https://mulescheduler-5b49a3fdb078.herokuapp.com`)
- The frontend and backend are served from the same domain on Heroku
- Hardcoded localhost URLs try to load from localhost in production, causing 404 errors

**Error Symptoms:**
- Profile pictures don't display in production
- Browser console shows 404 errors for image requests
- Images try to load from `http://localhost:5000/uploads/profile_pictures/...` even on Heroku
- Default avatar fallback is shown instead of actual profile pictures

**Impact:**
- Users cannot see profile pictures in production
- Poor user experience
- Profile picture feature is broken on Heroku
- Works in development but fails in production

### How

#### Solution: Use Relative URLs

**Files Modified:**
- `frontend/src/components/ShiftScheduleGrid.tsx`
- `frontend/src/components/ProfileEditModal.tsx`
- `frontend/src/components/AppShell.tsx`

**Before:**
```typescript
user.profile_picture_url.startsWith('http')
  ? user.profile_picture_url
  : `http://localhost:5000${user.profile_picture_url}`
```

**After:**
```typescript
user.profile_picture_url.startsWith('http')
  ? user.profile_picture_url
  : user.profile_picture_url  // Use relative URL directly
```

**What this does:**
- Removes hardcoded `http://localhost:5000` prefix
- Uses relative URLs (e.g., `/uploads/profile_pictures/filename.jpg`)
- Browser resolves relative URLs against current origin
- Works in both development and production environments

### Acceptance Criteria

- [x] Hardcoded `localhost:5000` URLs removed from all components
- [x] Relative URLs used for profile pictures
- [x] Profile pictures work in development
- [x] Profile pictures work in production (Heroku)
- [x] External URLs (starting with `http`) still work
- [x] No breaking changes to existing functionality
- [x] All CI checks pass
- [x] Build completes successfully

### Testing

- ✅ Profile pictures display correctly in development
- ✅ Profile pictures display correctly in production
- ✅ Relative URLs resolve correctly
- ✅ External URLs still work
- ✅ No console errors
- ✅ Build succeeds

Closes #42