### PR TITLE
feat: Add dark mode toggle option

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Dropdown } from 'react-bootstrap';
 import { useAuth } from '../contexts/AuthContext';
@@ -170,6 +170,42 @@ const Icons = {
       <polyline points="6 9 12 15 18 9" />
     </svg>
   ),
+  Sun: () => (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  ),
+  Moon: () => (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  ),
 };
 
 // Simple MS Logo
@@ -205,6 +241,28 @@ const AppShell: React.FC<AppShellProps> = ({ children, pageTitle }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const [showProfileModal, setShowProfileModal] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(() => {
+    // Check localStorage first, then system preference
+    const stored = localStorage.getItem('theme');
+    if (stored) return stored === 'dark';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  // Apply theme to document
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isDarkMode) {
+      root.setAttribute('data-theme', 'dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      root.setAttribute('data-theme', 'light');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [isDarkMode]);
+
+  const toggleDarkMode = () => {
+    setIsDarkMode((prev) => !prev);
+  };
 
   const isActive = (path: string) => location.pathname === path;
   const isAdmin = user?.role === 'admin';
@@ -390,22 +448,33 @@ const AppShell: React.FC<AppShellProps> = ({ children, pageTitle }) => {
               <Dropdown.Menu
                 style={{
                   borderRadius: '14px',
-                  boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
-                  border: '1px solid #E5E7EB',
+                  boxShadow: 'var(--ms-shadow-md, 0 8px 24px rgba(0,0,0,0.12))',
+                  border: '1px solid var(--ms-border, #E5E7EB)',
                   padding: '8px',
+                  background: 'var(--ms-card-bg, #ffffff)',
                 }}
               >
                 <div
                   style={{
                     padding: '12px 16px',
-                    borderBottom: '1px solid #E5E7EB',
+                    borderBottom: '1px solid var(--ms-border, #E5E7EB)',
                     marginBottom: '8px',
                   }}
                 >
-                  <div style={{ fontWeight: 600, color: '#000' }}>{user?.name}</div>
-                  <div style={{ fontSize: '0.8rem', color: '#6B7280' }}>{user?.email}</div>
+                  <div style={{ fontWeight: 600, color: 'var(--ms-text-primary, #000)' }}>
+                    {user?.name}
+                  </div>
+                  <div style={{ fontSize: '0.8rem', color: 'var(--ms-text-muted, #6B7280)' }}>
+                    {user?.email}
+                  </div>
                   {user?.class_year && (
-                    <div style={{ fontSize: '0.75rem', color: '#6B7280', marginTop: '4px' }}>
+                    <div
+                      style={{
+                        fontSize: '0.75rem',
+                        color: 'var(--ms-text-muted, #6B7280)',
+                        marginTop: '4px',
+                      }}
+                    >
                       Class of {user.class_year}
                     </div>
                   )}
@@ -413,7 +482,7 @@ const AppShell: React.FC<AppShellProps> = ({ children, pageTitle }) => {
                     <div
                       style={{
                         fontSize: '0.75rem',
-                        color: '#6B7280',
+                        color: 'var(--ms-text-muted, #6B7280)',
                         marginTop: '6px',
                         fontStyle: 'italic',
                       }}
@@ -439,16 +508,32 @@ const AppShell: React.FC<AppShellProps> = ({ children, pageTitle }) => {
                     gap: '8px',
                     padding: '10px 16px',
                     marginBottom: '4px',
+                    color: 'var(--ms-text-primary, inherit)',
                   }}
                 >
                   <Icons.Settings />
                   Edit Profile
                 </Dropdown.Item>
                 <Dropdown.Item
+                  onClick={toggleDarkMode}
+                  style={{
+                    borderRadius: '8px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    padding: '10px 16px',
+                    marginBottom: '4px',
+                    color: 'var(--ms-text-primary, inherit)',
+                  }}
+                >
+                  {isDarkMode ? <Icons.Sun /> : <Icons.Moon />}
+                  {isDarkMode ? 'Light Mode' : 'Dark Mode'}
+                </Dropdown.Item>
+                <Dropdown.Item
                   onClick={handleLogout}
                   style={{
                     borderRadius: '8px',
-                    color: '#EF4444',
+                    color: 'var(--ms-danger, #EF4444)',
                     display: 'flex',
                     alignItems: 'center',
                     gap: '8px',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -142,3 +142,119 @@ button {
 .list-group-flush > .list-group-item:first-child {
   border-top: none;
 }
+
+/* =============================================================================
+   DARK MODE - Global Styles
+   ============================================================================= */
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    color-scheme: dark;
+  }
+
+  :root:not([data-theme='light']) body {
+    background-color: #0f172a;
+    color: #f1f5f9;
+  }
+
+  /* Custom scrollbar for dark mode */
+  :root:not([data-theme='light']) ::-webkit-scrollbar-track {
+    background: #0f172a;
+  }
+
+  :root:not([data-theme='light']) ::-webkit-scrollbar-thumb {
+    background: #334155;
+    border-color: #0f172a;
+  }
+
+  :root:not([data-theme='light']) ::-webkit-scrollbar-thumb:hover {
+    background: #475569;
+  }
+
+  /* Selection styling for dark mode */
+  :root:not([data-theme='light']) ::selection {
+    background: rgba(56, 189, 248, 0.4);
+    color: inherit;
+  }
+
+  /* Focus outline for dark mode */
+  :root:not([data-theme='light']) *:focus-visible {
+    outline-color: var(--ms-sky, #38bdf8);
+  }
+
+  /* Dropdown menus */
+  :root:not([data-theme='light']) .dropdown-menu {
+    background-color: #1e293b;
+    border-color: #334155;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+
+  :root:not([data-theme='light']) .dropdown-item {
+    color: #e2e8f0;
+  }
+
+  :root:not([data-theme='light']) .dropdown-item:hover {
+    background: #334155;
+    color: #f1f5f9;
+  }
+
+  /* List group items */
+  :root:not([data-theme='light']) .list-group-item {
+    background-color: #1e293b;
+    border-color: #334155;
+    color: #e2e8f0;
+  }
+}
+
+/* Manual dark mode toggle */
+[data-theme='dark'] {
+  color-scheme: dark;
+}
+
+[data-theme='dark'] body {
+  background-color: #0f172a;
+  color: #f1f5f9;
+}
+
+[data-theme='dark'] ::-webkit-scrollbar-track {
+  background: #0f172a;
+}
+
+[data-theme='dark'] ::-webkit-scrollbar-thumb {
+  background: #334155;
+  border-color: #0f172a;
+}
+
+[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
+  background: #475569;
+}
+
+[data-theme='dark'] ::selection {
+  background: rgba(56, 189, 248, 0.4);
+  color: inherit;
+}
+
+[data-theme='dark'] *:focus-visible {
+  outline-color: var(--ms-sky, #38bdf8);
+}
+
+[data-theme='dark'] .dropdown-menu {
+  background-color: #1e293b;
+  border-color: #334155;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme='dark'] .dropdown-item {
+  color: #e2e8f0;
+}
+
+[data-theme='dark'] .dropdown-item:hover {
+  background: #334155;
+  color: #f1f5f9;
+}
+
+[data-theme='dark'] .list-group-item {
+  background-color: #1e293b;
+  border-color: #334155;
+  color: #e2e8f0;
+}

--- a/frontend/src/styles/calendar-overrides.css
+++ b/frontend/src/styles/calendar-overrides.css
@@ -114,3 +114,98 @@
     padding: 0.2rem 0.4rem;
   }
 }
+
+/* ============================================
+   DARK MODE - FullCalendar Overrides
+   ============================================ */
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .fc {
+    --fc-border-color: #334155;
+    --fc-page-bg-color: #0f172a;
+    --fc-neutral-bg-color: #1e293b;
+    --fc-today-bg-color: rgba(56, 189, 248, 0.15);
+  }
+
+  :root:not([data-theme='light']) .fc .fc-timegrid-col {
+    border-left-color: #334155;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-timegrid-event {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  }
+
+  :root:not([data-theme='light']) .fc .fc-timegrid-event:hover {
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  }
+
+  :root:not([data-theme='light']) .fc .fc-timegrid-event.fc-event-dragging {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
+  }
+
+  :root:not([data-theme='light']) .fc .fc-timegrid-axis {
+    background-color: #1e293b;
+    color: #94a3b8;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-timegrid-slot-label {
+    color: #94a3b8;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-col-header-cell-cushion {
+    color: #e2e8f0;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-daygrid-day-number {
+    color: #e2e8f0;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-toolbar-title {
+    color: #f1f5f9;
+  }
+}
+
+/* Manual dark mode toggle */
+[data-theme='dark'] .fc {
+  --fc-border-color: #334155;
+  --fc-page-bg-color: #0f172a;
+  --fc-neutral-bg-color: #1e293b;
+  --fc-today-bg-color: rgba(56, 189, 248, 0.15);
+}
+
+[data-theme='dark'] .fc .fc-timegrid-col {
+  border-left-color: #334155;
+}
+
+[data-theme='dark'] .fc .fc-timegrid-event {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme='dark'] .fc .fc-timegrid-event:hover {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+
+[data-theme='dark'] .fc .fc-timegrid-event.fc-event-dragging {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
+}
+
+[data-theme='dark'] .fc .fc-timegrid-axis {
+  background-color: #1e293b;
+  color: #94a3b8;
+}
+
+[data-theme='dark'] .fc .fc-timegrid-slot-label {
+  color: #94a3b8;
+}
+
+[data-theme='dark'] .fc .fc-col-header-cell-cushion {
+  color: #e2e8f0;
+}
+
+[data-theme='dark'] .fc .fc-daygrid-day-number {
+  color: #e2e8f0;
+}
+
+[data-theme='dark'] .fc .fc-toolbar-title {
+  color: #f1f5f9;
+}

--- a/frontend/src/styles/custom-theme.css
+++ b/frontend/src/styles/custom-theme.css
@@ -603,3 +603,630 @@ body {
   position: relative;
   z-index: 1;
 }
+
+/* =============================================================================
+   DARK MODE - Bootstrap Component Overrides
+   ============================================================================= */
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    /* Bootstrap Variable Overrides for Dark Mode */
+    --bs-body-bg: #0f172a;
+    --bs-body-color: #f1f5f9;
+    --bs-primary: #38bdf8;
+    --bs-primary-rgb: 56, 189, 248;
+    --bs-secondary: #60a5fa;
+    --bs-secondary-rgb: 96, 165, 250;
+    --bs-success: #34d399;
+    --bs-info: #60a5fa;
+    --bs-border-color: #334155;
+
+    /* Color Palette Overrides */
+    --color-primary: #34d399;
+    --color-primary-dark: #6ee7b7;
+    --color-primary-border: #34d399;
+    --color-primary-darker: #a7f3d0;
+    --color-primary-bg: #064e3b;
+
+    --color-colby-blue: #3b82f6;
+    --color-colby-blue-light: #60a5fa;
+    --color-colby-blue-bg: #1e3a5f;
+
+    --color-gray-50: #1e293b;
+    --color-gray-100: #334155;
+    --color-gray-200: #475569;
+    --color-gray-300: #64748b;
+    --color-gray-400: #94a3b8;
+    --color-gray-500: #cbd5e1;
+    --color-gray-600: #e2e8f0;
+    --color-gray-700: #f1f5f9;
+    --color-gray-800: #f8fafc;
+    --color-gray-900: #ffffff;
+
+    --color-text: #f1f5f9;
+    --color-text-muted: #94a3b8;
+    --color-bg: #0f172a;
+    --color-bg-light: #1e293b;
+
+    --color-border: #334155;
+    --color-border-primary: #34d399;
+  }
+
+  /* Body background */
+  :root:not([data-theme='light']) body {
+    background-color: #0f172a;
+    color: #f1f5f9;
+  }
+
+  /* Button Primary */
+  :root:not([data-theme='light']) .btn-primary {
+    background-color: #064e3b;
+    border-color: #34d399;
+    color: #a7f3d0;
+  }
+
+  :root:not([data-theme='light']) .btn-primary:hover {
+    background-color: #34d399;
+    border-color: #6ee7b7;
+    color: #0f172a;
+  }
+
+  /* Button Secondary */
+  :root:not([data-theme='light']) .btn-secondary {
+    background-color: #1e3a5f;
+    border-color: #3b82f6;
+    color: #93c5fd;
+  }
+
+  :root:not([data-theme='light']) .btn-secondary:hover {
+    background-color: #3b82f6;
+    border-color: #60a5fa;
+    color: #ffffff;
+  }
+
+  /* Button Outline Primary */
+  :root:not([data-theme='light']) .btn-outline-primary {
+    border-color: #34d399;
+    color: #6ee7b7;
+  }
+
+  :root:not([data-theme='light']) .btn-outline-primary:hover {
+    background-color: #064e3b;
+    border-color: #34d399;
+    color: #a7f3d0;
+  }
+
+  /* Cards */
+  :root:not([data-theme='light']) .card {
+    background: #1e293b;
+    border-color: #334155;
+  }
+
+  :root:not([data-theme='light']) .card-header {
+    background-color: #334155;
+    border-bottom-color: #475569;
+  }
+
+  /* Navbar */
+  :root:not([data-theme='light']) .navbar {
+    background-color: #1e293b !important;
+    border-bottom-color: #334155;
+  }
+
+  :root:not([data-theme='light']) .navbar-brand {
+    color: #38bdf8 !important;
+  }
+
+  :root:not([data-theme='light']) .nav-link {
+    color: #cbd5e1 !important;
+  }
+
+  :root:not([data-theme='light']) .nav-link:hover {
+    background-color: #334155;
+    color: #f1f5f9 !important;
+  }
+
+  /* Form Controls */
+  :root:not([data-theme='light']) .form-control,
+  :root:not([data-theme='light']) .form-select {
+    background-color: #1e293b;
+    border-color: #334155;
+    color: #f1f5f9;
+  }
+
+  :root:not([data-theme='light']) .form-control:focus,
+  :root:not([data-theme='light']) .form-select:focus {
+    background-color: #1e293b;
+    border-color: #34d399;
+    box-shadow: 0 0 0 0.25rem rgba(52, 211, 153, 0.25);
+    color: #f1f5f9;
+  }
+
+  :root:not([data-theme='light']) .form-control::placeholder {
+    color: #64748b;
+  }
+
+  /* Tables */
+  :root:not([data-theme='light']) .table {
+    color: #f1f5f9;
+  }
+
+  :root:not([data-theme='light']) .table thead {
+    background-color: #334155;
+  }
+
+  :root:not([data-theme='light']) .table thead th {
+    border-bottom-color: #475569;
+    color: #e2e8f0;
+  }
+
+  :root:not([data-theme='light']) .table tbody td {
+    border-color: #334155;
+  }
+
+  :root:not([data-theme='light']) .table tbody tr:hover {
+    background-color: #334155;
+  }
+
+  :root:not([data-theme='light']) .table-striped tbody tr:nth-of-type(odd) {
+    background-color: #1e293b;
+  }
+
+  /* Modals */
+  :root:not([data-theme='light']) .modal-content {
+    background-color: #1e293b;
+    border-color: #334155;
+  }
+
+  :root:not([data-theme='light']) .modal-header {
+    background-color: #334155;
+    border-bottom-color: #475569;
+  }
+
+  :root:not([data-theme='light']) .modal-header .modal-title {
+    color: #f1f5f9;
+  }
+
+  :root:not([data-theme='light']) .modal-footer {
+    background-color: #334155;
+    border-top-color: #475569;
+  }
+
+  /* Alerts */
+  :root:not([data-theme='light']) .alert-primary {
+    background-color: #064e3b;
+    border-color: #34d399;
+    color: #a7f3d0;
+  }
+
+  :root:not([data-theme='light']) .alert-success {
+    background-color: #064e3b;
+    border-color: #34d399;
+    color: #a7f3d0;
+  }
+
+  :root:not([data-theme='light']) .alert-danger {
+    background-color: #450a0a;
+    border-color: #f87171;
+    color: #fca5a5;
+  }
+
+  :root:not([data-theme='light']) .alert-warning {
+    background-color: #451a03;
+    border-color: #fbbf24;
+    color: #fde68a;
+  }
+
+  :root:not([data-theme='light']) .alert-info {
+    background-color: #1e3a5f;
+    border-color: #3b82f6;
+    color: #93c5fd;
+  }
+
+  /* Badges */
+  :root:not([data-theme='light']) .badge.bg-primary {
+    background-color: #064e3b !important;
+    border-color: #34d399;
+    color: #a7f3d0;
+  }
+
+  :root:not([data-theme='light']) .badge.bg-secondary {
+    background-color: #1e3a5f !important;
+    border-color: #3b82f6;
+    color: #93c5fd;
+  }
+
+  /* Dropdowns */
+  :root:not([data-theme='light']) .dropdown-menu {
+    background-color: #1e293b;
+    border-color: #334155;
+  }
+
+  :root:not([data-theme='light']) .dropdown-item {
+    color: #e2e8f0;
+  }
+
+  :root:not([data-theme='light']) .dropdown-item:hover {
+    background-color: #334155;
+    color: #f1f5f9;
+  }
+
+  :root:not([data-theme='light']) .dropdown-item:active {
+    background-color: #064e3b;
+    color: #a7f3d0;
+  }
+
+  /* FullCalendar */
+  :root:not([data-theme='light']) .fc {
+    --fc-border-color: #334155;
+    --fc-page-bg-color: #0f172a;
+    --fc-neutral-bg-color: #1e293b;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-button {
+    background-color: #064e3b !important;
+    border-color: #34d399 !important;
+    color: #a7f3d0 !important;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-button:hover {
+    background-color: #34d399 !important;
+    border-color: #6ee7b7 !important;
+    color: #0f172a !important;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-event {
+    background-color: #064e3b !important;
+    border-left-color: #34d399 !important;
+    color: #a7f3d0 !important;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-event:hover {
+    background-color: #34d399 !important;
+    color: #0f172a !important;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-daygrid-day {
+    border-color: #334155 !important;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-col-header-cell {
+    background-color: #334155 !important;
+    border-color: #475569 !important;
+    color: #e2e8f0 !important;
+  }
+
+  :root:not([data-theme='light']) .fc .fc-day-today {
+    background-color: #0c4a6e !important;
+  }
+
+  /* Focus visible */
+  :root:not([data-theme='light']) *:focus-visible {
+    outline-color: #34d399;
+  }
+
+  /* List group items */
+  :root:not([data-theme='light']) .list-group-item {
+    background-color: #1e293b;
+    border-color: #334155;
+    color: #e2e8f0;
+  }
+
+  /* Schedule blocks */
+  :root:not([data-theme='light']) .schedule-block {
+    background-color: #064e3b;
+    border-color: #34d399;
+    color: #a7f3d0;
+  }
+
+  :root:not([data-theme='light']) .schedule-block:hover,
+  :root:not([data-theme='light']) .schedule-block.active {
+    background-color: #34d399;
+    border-color: #6ee7b7;
+    color: #0f172a;
+  }
+
+  /* Login page left overlay */
+  :root:not([data-theme='light']) .login-left-overlay {
+    background-color: rgba(15, 23, 42, 0.85);
+  }
+}
+
+/* Manual Dark Mode Toggle Support */
+[data-theme='dark'] {
+  --bs-body-bg: #0f172a;
+  --bs-body-color: #f1f5f9;
+  --bs-primary: #38bdf8;
+  --bs-primary-rgb: 56, 189, 248;
+  --bs-secondary: #60a5fa;
+  --bs-secondary-rgb: 96, 165, 250;
+  --bs-success: #34d399;
+  --bs-info: #60a5fa;
+  --bs-border-color: #334155;
+
+  --color-primary: #34d399;
+  --color-primary-dark: #6ee7b7;
+  --color-primary-border: #34d399;
+  --color-primary-darker: #a7f3d0;
+  --color-primary-bg: #064e3b;
+
+  --color-colby-blue: #3b82f6;
+  --color-colby-blue-light: #60a5fa;
+  --color-colby-blue-bg: #1e3a5f;
+
+  --color-gray-50: #1e293b;
+  --color-gray-100: #334155;
+  --color-gray-200: #475569;
+  --color-gray-300: #64748b;
+  --color-gray-400: #94a3b8;
+  --color-gray-500: #cbd5e1;
+  --color-gray-600: #e2e8f0;
+  --color-gray-700: #f1f5f9;
+  --color-gray-800: #f8fafc;
+  --color-gray-900: #ffffff;
+
+  --color-text: #f1f5f9;
+  --color-text-muted: #94a3b8;
+  --color-bg: #0f172a;
+  --color-bg-light: #1e293b;
+
+  --color-border: #334155;
+  --color-border-primary: #34d399;
+}
+
+[data-theme='dark'] body {
+  background-color: #0f172a;
+  color: #f1f5f9;
+}
+
+[data-theme='dark'] .btn-primary {
+  background-color: #064e3b;
+  border-color: #34d399;
+  color: #a7f3d0;
+}
+
+[data-theme='dark'] .btn-primary:hover {
+  background-color: #34d399;
+  border-color: #6ee7b7;
+  color: #0f172a;
+}
+
+[data-theme='dark'] .btn-secondary {
+  background-color: #1e3a5f;
+  border-color: #3b82f6;
+  color: #93c5fd;
+}
+
+[data-theme='dark'] .btn-secondary:hover {
+  background-color: #3b82f6;
+  border-color: #60a5fa;
+  color: #ffffff;
+}
+
+[data-theme='dark'] .btn-outline-primary {
+  border-color: #34d399;
+  color: #6ee7b7;
+}
+
+[data-theme='dark'] .btn-outline-primary:hover {
+  background-color: #064e3b;
+  border-color: #34d399;
+  color: #a7f3d0;
+}
+
+[data-theme='dark'] .card {
+  background: #1e293b;
+  border-color: #334155;
+}
+
+[data-theme='dark'] .card-header {
+  background-color: #334155;
+  border-bottom-color: #475569;
+}
+
+[data-theme='dark'] .navbar {
+  background-color: #1e293b !important;
+  border-bottom-color: #334155;
+}
+
+[data-theme='dark'] .navbar-brand {
+  color: #38bdf8 !important;
+}
+
+[data-theme='dark'] .nav-link {
+  color: #cbd5e1 !important;
+}
+
+[data-theme='dark'] .nav-link:hover {
+  background-color: #334155;
+  color: #f1f5f9 !important;
+}
+
+[data-theme='dark'] .form-control,
+[data-theme='dark'] .form-select {
+  background-color: #1e293b;
+  border-color: #334155;
+  color: #f1f5f9;
+}
+
+[data-theme='dark'] .form-control:focus,
+[data-theme='dark'] .form-select:focus {
+  background-color: #1e293b;
+  border-color: #34d399;
+  box-shadow: 0 0 0 0.25rem rgba(52, 211, 153, 0.25);
+  color: #f1f5f9;
+}
+
+[data-theme='dark'] .form-control::placeholder {
+  color: #64748b;
+}
+
+[data-theme='dark'] .table {
+  color: #f1f5f9;
+}
+
+[data-theme='dark'] .table thead {
+  background-color: #334155;
+}
+
+[data-theme='dark'] .table thead th {
+  border-bottom-color: #475569;
+  color: #e2e8f0;
+}
+
+[data-theme='dark'] .table tbody td {
+  border-color: #334155;
+}
+
+[data-theme='dark'] .table tbody tr:hover {
+  background-color: #334155;
+}
+
+[data-theme='dark'] .table-striped tbody tr:nth-of-type(odd) {
+  background-color: #1e293b;
+}
+
+[data-theme='dark'] .modal-content {
+  background-color: #1e293b;
+  border-color: #334155;
+}
+
+[data-theme='dark'] .modal-header {
+  background-color: #334155;
+  border-bottom-color: #475569;
+}
+
+[data-theme='dark'] .modal-header .modal-title {
+  color: #f1f5f9;
+}
+
+[data-theme='dark'] .modal-footer {
+  background-color: #334155;
+  border-top-color: #475569;
+}
+
+[data-theme='dark'] .alert-primary,
+[data-theme='dark'] .alert-success {
+  background-color: #064e3b;
+  border-color: #34d399;
+  color: #a7f3d0;
+}
+
+[data-theme='dark'] .alert-danger {
+  background-color: #450a0a;
+  border-color: #f87171;
+  color: #fca5a5;
+}
+
+[data-theme='dark'] .alert-warning {
+  background-color: #451a03;
+  border-color: #fbbf24;
+  color: #fde68a;
+}
+
+[data-theme='dark'] .alert-info {
+  background-color: #1e3a5f;
+  border-color: #3b82f6;
+  color: #93c5fd;
+}
+
+[data-theme='dark'] .badge.bg-primary {
+  background-color: #064e3b !important;
+  border-color: #34d399;
+  color: #a7f3d0;
+}
+
+[data-theme='dark'] .badge.bg-secondary {
+  background-color: #1e3a5f !important;
+  border-color: #3b82f6;
+  color: #93c5fd;
+}
+
+[data-theme='dark'] .dropdown-menu {
+  background-color: #1e293b;
+  border-color: #334155;
+}
+
+[data-theme='dark'] .dropdown-item {
+  color: #e2e8f0;
+}
+
+[data-theme='dark'] .dropdown-item:hover {
+  background-color: #334155;
+  color: #f1f5f9;
+}
+
+[data-theme='dark'] .dropdown-item:active {
+  background-color: #064e3b;
+  color: #a7f3d0;
+}
+
+[data-theme='dark'] .fc {
+  --fc-border-color: #334155;
+  --fc-page-bg-color: #0f172a;
+  --fc-neutral-bg-color: #1e293b;
+}
+
+[data-theme='dark'] .fc .fc-button {
+  background-color: #064e3b !important;
+  border-color: #34d399 !important;
+  color: #a7f3d0 !important;
+}
+
+[data-theme='dark'] .fc .fc-button:hover {
+  background-color: #34d399 !important;
+  border-color: #6ee7b7 !important;
+  color: #0f172a !important;
+}
+
+[data-theme='dark'] .fc .fc-event {
+  background-color: #064e3b !important;
+  border-left-color: #34d399 !important;
+  color: #a7f3d0 !important;
+}
+
+[data-theme='dark'] .fc .fc-event:hover {
+  background-color: #34d399 !important;
+  color: #0f172a !important;
+}
+
+[data-theme='dark'] .fc .fc-daygrid-day {
+  border-color: #334155 !important;
+}
+
+[data-theme='dark'] .fc .fc-col-header-cell {
+  background-color: #334155 !important;
+  border-color: #475569 !important;
+  color: #e2e8f0 !important;
+}
+
+[data-theme='dark'] .fc .fc-day-today {
+  background-color: #0c4a6e !important;
+}
+
+[data-theme='dark'] *:focus-visible {
+  outline-color: #34d399;
+}
+
+[data-theme='dark'] .list-group-item {
+  background-color: #1e293b;
+  border-color: #334155;
+  color: #e2e8f0;
+}
+
+[data-theme='dark'] .schedule-block {
+  background-color: #064e3b;
+  border-color: #34d399;
+  color: #a7f3d0;
+}
+
+[data-theme='dark'] .schedule-block:hover,
+[data-theme='dark'] .schedule-block.active {
+  background-color: #34d399;
+  border-color: #6ee7b7;
+  color: #0f172a;
+}
+
+[data-theme='dark'] .login-left-overlay {
+  background-color: rgba(15, 23, 42, 0.85);
+}

--- a/frontend/src/styles/scheduler.css
+++ b/frontend/src/styles/scheduler.css
@@ -2918,6 +2918,639 @@ body {
 }
 
 /* =============================================================================
+   DARK MODE - System Preference & Manual Toggle Support
+   ============================================================================= */
+
+/* Dark mode variables - activated by system preference OR manual toggle */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    /* =============================================
+       BACKGROUND SYSTEM - Dark Canvas
+       ============================================= */
+    --ms-bg: #0f172a;
+    --ms-bg-soft: #1e293b;
+    --ms-card-bg: #1e293b;
+    --ms-surface: #334155;
+    --ms-surface-elevated: #475569;
+
+    /* =============================================
+       TEXT COLORS - Light on Dark
+       ============================================= */
+    --ms-text-primary: #f1f5f9;
+    --ms-text-secondary: #e2e8f0;
+    --ms-text-body: #cbd5e1;
+    --ms-text-muted: #94a3b8;
+    --ms-text-inverse: #0f172a;
+    --ms-text-link: #60a5fa;
+
+    /* =============================================
+       BRAND - Colby Blue (adjusted for dark)
+       ============================================= */
+    --ms-colby-blue: #3b82f6;
+    --ms-colby-blue-light: #60a5fa;
+    --ms-colby-gold: #fbbf24;
+
+    /* =============================================
+       PASTEL ACCENT PALETTE - Adjusted for Dark
+       ============================================= */
+    /* Mint / Lime Green */
+    --ms-mint: #34d399;
+    --ms-mint-light: #064e3b;
+    --ms-mint-dark: #6ee7b7;
+
+    /* Aqua / Cyan */
+    --ms-aqua: #22d3ee;
+    --ms-aqua-light: #083344;
+    --ms-aqua-dark: #67e8f9;
+
+    /* Sky Blue */
+    --ms-sky: #38bdf8;
+    --ms-sky-light: #0c4a6e;
+    --ms-sky-dark: #7dd3fc;
+
+    /* Coral / Peach */
+    --ms-coral: #fb7185;
+    --ms-coral-light: #4c0519;
+    --ms-coral-dark: #fda4af;
+
+    /* Lavender / Violet */
+    --ms-lavender: #a78bfa;
+    --ms-lavender-light: #2e1065;
+    --ms-lavender-dark: #c4b5fd;
+
+    /* Soft Yellow / Amber */
+    --ms-yellow: #fbbf24;
+    --ms-yellow-light: #451a03;
+    --ms-yellow-dark: #fde68a;
+
+    /* Pink / Rose */
+    --ms-pink: #f472b6;
+    --ms-pink-light: #500724;
+    --ms-pink-dark: #f9a8d4;
+
+    /* Indigo / Blue */
+    --ms-indigo: #818cf8;
+    --ms-indigo-light: #1e1b4b;
+    --ms-indigo-dark: #a5b4fc;
+
+    /* =============================================
+       SEMANTIC COLORS - Dark Mode
+       ============================================= */
+    --ms-success: #34d399;
+    --ms-success-light: #064e3b;
+    --ms-success-dark: #6ee7b7;
+
+    --ms-warning: #fbbf24;
+    --ms-warning-light: #451a03;
+    --ms-warning-dark: #fde68a;
+
+    --ms-danger: #f87171;
+    --ms-danger-light: #450a0a;
+    --ms-danger-dark: #fca5a5;
+
+    --ms-info: #60a5fa;
+    --ms-info-light: #1e3a5f;
+    --ms-info-dark: #93c5fd;
+
+    /* =============================================
+       LOCATION COLORS - Dark Mode Pastels
+       ============================================= */
+    --ms-loc-1: #34d399;
+    --ms-loc-1-bg: #064e3b;
+    --ms-loc-2: #fb7185;
+    --ms-loc-2-bg: #4c0519;
+    --ms-loc-3: #fbbf24;
+    --ms-loc-3-bg: #451a03;
+    --ms-loc-4: #a78bfa;
+    --ms-loc-4-bg: #2e1065;
+    --ms-loc-5: #38bdf8;
+    --ms-loc-5-bg: #0c4a6e;
+    --ms-loc-6: #f472b6;
+    --ms-loc-6-bg: #500724;
+
+    /* =============================================
+       BORDER COLORS - Dark Mode
+       ============================================= */
+    --ms-border: #334155;
+    --ms-border-light: #1e293b;
+    --ms-border-dark: rgba(255, 255, 255, 0.15);
+    --ms-border-focus: #60a5fa;
+
+    /* =============================================
+       SHADOWS - Dark Mode (more subtle)
+       ============================================= */
+    --ms-shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+    --ms-shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+    --ms-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+    --ms-shadow-md: 0 8px 24px rgba(0, 0, 0, 0.5);
+    --ms-shadow-lg: 0 16px 40px rgba(0, 0, 0, 0.6);
+    --ms-shadow-xl: 0 24px 48px rgba(0, 0, 0, 0.7);
+    --ms-shadow-card: 0 2px 12px rgba(0, 0, 0, 0.4), 0 4px 24px rgba(0, 0, 0, 0.3);
+    --ms-shadow-colored: 0 4px 14px rgba(59, 130, 246, 0.3);
+
+    /* =============================================
+       STAT CARD COLORS - Dark Mode
+       ============================================= */
+    --ms-stat-sky: #0c4a6e;
+    --ms-stat-sky-accent: #38bdf8;
+    --ms-stat-sky-dark: #7dd3fc;
+
+    --ms-stat-mint: #064e3b;
+    --ms-stat-mint-accent: #34d399;
+    --ms-stat-mint-dark: #6ee7b7;
+
+    --ms-stat-yellow: #451a03;
+    --ms-stat-yellow-accent: #fbbf24;
+    --ms-stat-yellow-dark: #fde68a;
+
+    --ms-stat-lavender: #2e1065;
+    --ms-stat-lavender-accent: #a78bfa;
+    --ms-stat-lavender-dark: #c4b5fd;
+
+    --ms-stat-coral: #4c0519;
+    --ms-stat-coral-accent: #fb7185;
+    --ms-stat-coral-dark: #fda4af;
+
+    --ms-stat-indigo: #1e1b4b;
+    --ms-stat-indigo-accent: #818cf8;
+    --ms-stat-indigo-dark: #a5b4fc;
+  }
+}
+
+/* Manual dark mode toggle support */
+[data-theme='dark'] {
+  /* =============================================
+     BACKGROUND SYSTEM - Dark Canvas
+     ============================================= */
+  --ms-bg: #0f172a;
+  --ms-bg-soft: #1e293b;
+  --ms-card-bg: #1e293b;
+  --ms-surface: #334155;
+  --ms-surface-elevated: #475569;
+
+  /* =============================================
+     TEXT COLORS - Light on Dark
+     ============================================= */
+  --ms-text-primary: #f1f5f9;
+  --ms-text-secondary: #e2e8f0;
+  --ms-text-body: #cbd5e1;
+  --ms-text-muted: #94a3b8;
+  --ms-text-inverse: #0f172a;
+  --ms-text-link: #60a5fa;
+
+  /* =============================================
+     BRAND - Colby Blue (adjusted for dark)
+     ============================================= */
+  --ms-colby-blue: #3b82f6;
+  --ms-colby-blue-light: #60a5fa;
+  --ms-colby-gold: #fbbf24;
+
+  /* =============================================
+     PASTEL ACCENT PALETTE - Adjusted for Dark
+     ============================================= */
+  --ms-mint: #34d399;
+  --ms-mint-light: #064e3b;
+  --ms-mint-dark: #6ee7b7;
+
+  --ms-aqua: #22d3ee;
+  --ms-aqua-light: #083344;
+  --ms-aqua-dark: #67e8f9;
+
+  --ms-sky: #38bdf8;
+  --ms-sky-light: #0c4a6e;
+  --ms-sky-dark: #7dd3fc;
+
+  --ms-coral: #fb7185;
+  --ms-coral-light: #4c0519;
+  --ms-coral-dark: #fda4af;
+
+  --ms-lavender: #a78bfa;
+  --ms-lavender-light: #2e1065;
+  --ms-lavender-dark: #c4b5fd;
+
+  --ms-yellow: #fbbf24;
+  --ms-yellow-light: #451a03;
+  --ms-yellow-dark: #fde68a;
+
+  --ms-pink: #f472b6;
+  --ms-pink-light: #500724;
+  --ms-pink-dark: #f9a8d4;
+
+  --ms-indigo: #818cf8;
+  --ms-indigo-light: #1e1b4b;
+  --ms-indigo-dark: #a5b4fc;
+
+  /* =============================================
+     SEMANTIC COLORS - Dark Mode
+     ============================================= */
+  --ms-success: #34d399;
+  --ms-success-light: #064e3b;
+  --ms-success-dark: #6ee7b7;
+
+  --ms-warning: #fbbf24;
+  --ms-warning-light: #451a03;
+  --ms-warning-dark: #fde68a;
+
+  --ms-danger: #f87171;
+  --ms-danger-light: #450a0a;
+  --ms-danger-dark: #fca5a5;
+
+  --ms-info: #60a5fa;
+  --ms-info-light: #1e3a5f;
+  --ms-info-dark: #93c5fd;
+
+  /* =============================================
+     LOCATION COLORS - Dark Mode
+     ============================================= */
+  --ms-loc-1: #34d399;
+  --ms-loc-1-bg: #064e3b;
+  --ms-loc-2: #fb7185;
+  --ms-loc-2-bg: #4c0519;
+  --ms-loc-3: #fbbf24;
+  --ms-loc-3-bg: #451a03;
+  --ms-loc-4: #a78bfa;
+  --ms-loc-4-bg: #2e1065;
+  --ms-loc-5: #38bdf8;
+  --ms-loc-5-bg: #0c4a6e;
+  --ms-loc-6: #f472b6;
+  --ms-loc-6-bg: #500724;
+
+  /* =============================================
+     BORDER COLORS - Dark Mode
+     ============================================= */
+  --ms-border: #334155;
+  --ms-border-light: #1e293b;
+  --ms-border-dark: rgba(255, 255, 255, 0.15);
+  --ms-border-focus: #60a5fa;
+
+  /* =============================================
+     SHADOWS - Dark Mode
+     ============================================= */
+  --ms-shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --ms-shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --ms-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  --ms-shadow-md: 0 8px 24px rgba(0, 0, 0, 0.5);
+  --ms-shadow-lg: 0 16px 40px rgba(0, 0, 0, 0.6);
+  --ms-shadow-xl: 0 24px 48px rgba(0, 0, 0, 0.7);
+  --ms-shadow-card: 0 2px 12px rgba(0, 0, 0, 0.4), 0 4px 24px rgba(0, 0, 0, 0.3);
+  --ms-shadow-colored: 0 4px 14px rgba(59, 130, 246, 0.3);
+
+  /* =============================================
+     STAT CARD COLORS - Dark Mode
+     ============================================= */
+  --ms-stat-sky: #0c4a6e;
+  --ms-stat-sky-accent: #38bdf8;
+  --ms-stat-sky-dark: #7dd3fc;
+
+  --ms-stat-mint: #064e3b;
+  --ms-stat-mint-accent: #34d399;
+  --ms-stat-mint-dark: #6ee7b7;
+
+  --ms-stat-yellow: #451a03;
+  --ms-stat-yellow-accent: #fbbf24;
+  --ms-stat-yellow-dark: #fde68a;
+
+  --ms-stat-lavender: #2e1065;
+  --ms-stat-lavender-accent: #a78bfa;
+  --ms-stat-lavender-dark: #c4b5fd;
+
+  --ms-stat-coral: #4c0519;
+  --ms-stat-coral-accent: #fb7185;
+  --ms-stat-coral-dark: #fda4af;
+
+  --ms-stat-indigo: #1e1b4b;
+  --ms-stat-indigo-accent: #818cf8;
+  --ms-stat-indigo-dark: #a5b4fc;
+}
+
+/* =============================================================================
+   DARK MODE - Element-Specific Overrides
+   ============================================================================= */
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) body,
+  :root:not([data-theme='light']) .ms-app-shell {
+    color-scheme: dark;
+  }
+
+  /* Sidebar brand name in dark mode */
+  :root:not([data-theme='light']) .ms-sidebar-brand-name {
+    color: var(--ms-sky);
+  }
+
+  /* Calendar schedule container */
+  :root:not([data-theme='light']) .calendar-schedule-container {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  }
+
+  /* Calendar headers */
+  :root:not([data-theme='light']) .calendar-day-header.today {
+    background: linear-gradient(135deg, var(--ms-sky-light) 0%, #0c4a6e 100%);
+  }
+
+  /* Worker cards */
+  :root:not([data-theme='light']) .calendar-worker-card,
+  :root:not([data-theme='light']) .draggable-worker {
+    background: var(--ms-surface);
+  }
+
+  /* Shift cards */
+  :root:not([data-theme='light']) .shift-card {
+    background: var(--ms-surface);
+    color: var(--ms-text-primary);
+  }
+
+  /* Empty state backgrounds */
+  :root:not([data-theme='light']) .ms-empty-state {
+    background: linear-gradient(135deg, var(--ms-surface) 0%, var(--ms-bg) 100%);
+  }
+
+  /* Hero section */
+  :root:not([data-theme='light']) .ms-hero-section {
+    background: linear-gradient(135deg, #1e3a5f 0%, #0c4a6e 100%);
+  }
+
+  /* Focus panel */
+  :root:not([data-theme='light']) .ms-focus-panel {
+    background: linear-gradient(180deg, #0c4a6e 0%, #1e3a5f 50%, #0c4a6e 100%);
+  }
+
+  /* Modal backdrop enhancement */
+  :root:not([data-theme='light']) .ms-drawer-backdrop {
+    background: rgba(0, 0, 0, 0.6);
+  }
+
+  /* Toast enhancements */
+  :root:not([data-theme='light']) .ms-toast {
+    box-shadow:
+      0 4px 20px rgba(0, 0, 0, 0.5),
+      0 2px 6px rgba(0, 0, 0, 0.4);
+  }
+
+  /* Stat card gradients in dark mode */
+  :root:not([data-theme='light']) .ms-stat-card.sky {
+    background: linear-gradient(135deg, var(--ms-stat-sky) 0%, #0f172a 100%);
+  }
+  :root:not([data-theme='light']) .ms-stat-card.mint {
+    background: linear-gradient(135deg, var(--ms-stat-mint) 0%, #0f172a 100%);
+  }
+  :root:not([data-theme='light']) .ms-stat-card.yellow {
+    background: linear-gradient(135deg, var(--ms-stat-yellow) 0%, #0f172a 100%);
+  }
+  :root:not([data-theme='light']) .ms-stat-card.lavender {
+    background: linear-gradient(135deg, var(--ms-stat-lavender) 0%, #0f172a 100%);
+  }
+  :root:not([data-theme='light']) .ms-stat-card.coral {
+    background: linear-gradient(135deg, var(--ms-stat-coral) 0%, #0f172a 100%);
+  }
+  :root:not([data-theme='light']) .ms-stat-card.indigo {
+    background: linear-gradient(135deg, var(--ms-stat-indigo) 0%, #0f172a 100%);
+  }
+
+  /* Alert gradients */
+  :root:not([data-theme='light']) .alert-success {
+    background: linear-gradient(135deg, var(--ms-mint-light) 0%, #064e3b 100%);
+  }
+  :root:not([data-theme='light']) .alert-danger {
+    background: linear-gradient(135deg, var(--ms-coral-light) 0%, #450a0a 100%);
+  }
+  :root:not([data-theme='light']) .alert-warning {
+    background: linear-gradient(135deg, var(--ms-yellow-light) 0%, #451a03 100%);
+  }
+  :root:not([data-theme='light']) .alert-info {
+    background: linear-gradient(135deg, var(--ms-sky-light) 0%, #0c4a6e 100%);
+  }
+
+  /* Toast gradients */
+  :root:not([data-theme='light']) .ms-toast-success {
+    background: linear-gradient(135deg, #064e3b 0%, var(--ms-mint-light) 100%);
+  }
+  :root:not([data-theme='light']) .ms-toast-danger {
+    background: linear-gradient(135deg, #450a0a 0%, var(--ms-coral-light) 100%);
+  }
+  :root:not([data-theme='light']) .ms-toast-warning {
+    background: linear-gradient(135deg, #451a03 0%, var(--ms-yellow-light) 100%);
+  }
+  :root:not([data-theme='light']) .ms-toast-info {
+    background: linear-gradient(135deg, #0c4a6e 0%, var(--ms-sky-light) 100%);
+  }
+
+  /* Availability grid */
+  :root:not([data-theme='light']) .availability-grid-table .day-header {
+    background: linear-gradient(135deg, var(--ms-sky-light) 0%, var(--ms-card-bg) 100%);
+  }
+
+  /* Range slider track in dark mode */
+  :root:not([data-theme='light']) input[type='range'] {
+    background: var(--ms-surface);
+  }
+
+  /* Calendar cell hover */
+  :root:not([data-theme='light']) .calendar-cell:hover {
+    background: rgba(56, 189, 248, 0.1);
+  }
+
+  /* Scrollbar in dark mode */
+  :root:not([data-theme='light']) ::-webkit-scrollbar-track {
+    background: var(--ms-bg);
+  }
+  :root:not([data-theme='light']) ::-webkit-scrollbar-thumb {
+    background: var(--ms-surface);
+    border-color: var(--ms-bg);
+  }
+  :root:not([data-theme='light']) ::-webkit-scrollbar-thumb:hover {
+    background: var(--ms-surface-elevated);
+  }
+}
+
+/* Manual dark mode toggle - Element-Specific Overrides */
+[data-theme='dark'] body,
+[data-theme='dark'] .ms-app-shell {
+  color-scheme: dark;
+}
+
+[data-theme='dark'] .ms-sidebar-brand-name {
+  color: var(--ms-sky);
+}
+
+[data-theme='dark'] .calendar-schedule-container {
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme='dark'] .calendar-day-header.today {
+  background: linear-gradient(135deg, var(--ms-sky-light) 0%, #0c4a6e 100%);
+}
+
+[data-theme='dark'] .calendar-worker-card,
+[data-theme='dark'] .draggable-worker {
+  background: var(--ms-surface);
+}
+
+[data-theme='dark'] .shift-card {
+  background: var(--ms-surface);
+  color: var(--ms-text-primary);
+}
+
+[data-theme='dark'] .ms-empty-state {
+  background: linear-gradient(135deg, var(--ms-surface) 0%, var(--ms-bg) 100%);
+}
+
+[data-theme='dark'] .ms-hero-section {
+  background: linear-gradient(135deg, #1e3a5f 0%, #0c4a6e 100%);
+}
+
+[data-theme='dark'] .ms-focus-panel {
+  background: linear-gradient(180deg, #0c4a6e 0%, #1e3a5f 50%, #0c4a6e 100%);
+}
+
+[data-theme='dark'] .ms-drawer-backdrop {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+[data-theme='dark'] .ms-toast {
+  box-shadow:
+    0 4px 20px rgba(0, 0, 0, 0.5),
+    0 2px 6px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme='dark'] .ms-stat-card.sky {
+  background: linear-gradient(135deg, var(--ms-stat-sky) 0%, #0f172a 100%);
+}
+[data-theme='dark'] .ms-stat-card.mint {
+  background: linear-gradient(135deg, var(--ms-stat-mint) 0%, #0f172a 100%);
+}
+[data-theme='dark'] .ms-stat-card.yellow {
+  background: linear-gradient(135deg, var(--ms-stat-yellow) 0%, #0f172a 100%);
+}
+[data-theme='dark'] .ms-stat-card.lavender {
+  background: linear-gradient(135deg, var(--ms-stat-lavender) 0%, #0f172a 100%);
+}
+[data-theme='dark'] .ms-stat-card.coral {
+  background: linear-gradient(135deg, var(--ms-stat-coral) 0%, #0f172a 100%);
+}
+[data-theme='dark'] .ms-stat-card.indigo {
+  background: linear-gradient(135deg, var(--ms-stat-indigo) 0%, #0f172a 100%);
+}
+
+[data-theme='dark'] .alert-success {
+  background: linear-gradient(135deg, var(--ms-mint-light) 0%, #064e3b 100%);
+}
+[data-theme='dark'] .alert-danger {
+  background: linear-gradient(135deg, var(--ms-coral-light) 0%, #450a0a 100%);
+}
+[data-theme='dark'] .alert-warning {
+  background: linear-gradient(135deg, var(--ms-yellow-light) 0%, #451a03 100%);
+}
+[data-theme='dark'] .alert-info {
+  background: linear-gradient(135deg, var(--ms-sky-light) 0%, #0c4a6e 100%);
+}
+
+[data-theme='dark'] .ms-toast-success {
+  background: linear-gradient(135deg, #064e3b 0%, var(--ms-mint-light) 100%);
+}
+[data-theme='dark'] .ms-toast-danger {
+  background: linear-gradient(135deg, #450a0a 0%, var(--ms-coral-light) 100%);
+}
+[data-theme='dark'] .ms-toast-warning {
+  background: linear-gradient(135deg, #451a03 0%, var(--ms-yellow-light) 100%);
+}
+[data-theme='dark'] .ms-toast-info {
+  background: linear-gradient(135deg, #0c4a6e 0%, var(--ms-sky-light) 100%);
+}
+
+[data-theme='dark'] .availability-grid-table .day-header {
+  background: linear-gradient(135deg, var(--ms-sky-light) 0%, var(--ms-card-bg) 100%);
+}
+
+[data-theme='dark'] input[type='range'] {
+  background: var(--ms-surface);
+}
+
+[data-theme='dark'] .calendar-cell:hover {
+  background: rgba(56, 189, 248, 0.1);
+}
+
+[data-theme='dark'] ::-webkit-scrollbar-track {
+  background: var(--ms-bg);
+}
+[data-theme='dark'] ::-webkit-scrollbar-thumb {
+  background: var(--ms-surface);
+  border-color: var(--ms-bg);
+}
+[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
+  background: var(--ms-surface-elevated);
+}
+
+/* Sidebar nav description visibility fix - white text on blue background */
+[data-theme='dark'] .ms-sidebar-nav-item-expanded {
+  background: rgba(59, 130, 246, 0.15);
+}
+
+[data-theme='dark'] .ms-sidebar-nav-item-expanded:hover {
+  background: rgba(59, 130, 246, 0.25);
+}
+
+[data-theme='dark'] .ms-sidebar-nav-item-expanded.active {
+  background: rgba(59, 130, 246, 0.3);
+}
+
+[data-theme='dark'] .ms-sidebar-nav-desc {
+  color: #e2e8f0;
+}
+
+[data-theme='dark'] .ms-sidebar-nav-label {
+  color: #ffffff;
+}
+
+[data-theme='dark'] .ms-sidebar-section-label {
+  color: #94a3b8;
+}
+
+[data-theme='dark'] .ms-sidebar-nav-icon {
+  color: #ffffff;
+}
+
+[data-theme='dark'] .ms-sidebar-nav-item-expanded.active .ms-sidebar-nav-icon {
+  background: rgba(59, 130, 246, 0.4);
+  color: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .ms-sidebar-nav-item-expanded {
+    background: rgba(59, 130, 246, 0.15);
+  }
+
+  :root:not([data-theme='light']) .ms-sidebar-nav-item-expanded:hover {
+    background: rgba(59, 130, 246, 0.25);
+  }
+
+  :root:not([data-theme='light']) .ms-sidebar-nav-item-expanded.active {
+    background: rgba(59, 130, 246, 0.3);
+  }
+
+  :root:not([data-theme='light']) .ms-sidebar-nav-desc {
+    color: #e2e8f0;
+  }
+
+  :root:not([data-theme='light']) .ms-sidebar-nav-label {
+    color: #ffffff;
+  }
+
+  :root:not([data-theme='light']) .ms-sidebar-section-label {
+    color: #94a3b8;
+  }
+
+  :root:not([data-theme='light']) .ms-sidebar-nav-icon {
+    color: #ffffff;
+  }
+
+  :root:not([data-theme='light']) .ms-sidebar-nav-item-expanded.active .ms-sidebar-nav-icon {
+    background: rgba(59, 130, 246, 0.4);
+    color: #ffffff;
+  }
+}
+
+/* =============================================================================
    NATIVE TOOLTIPS - Uses browser's native title attribute for clean hover
    ============================================================================= */
 


### PR DESCRIPTION
# Add Dark Mode Support (feature/dark-mode)

## What  
- Introduces a new **Dark Mode** theme option to the application UI.  
- Adds a toggle (or configuration option) for Dark Mode in the settings/menu.  
- Implements global dark-theme CSS variables and overrides existing styles so that major UI components (sidebar, navigation, cards, forms, tables, modals, etc.) render appropriately in Dark Mode.  
- Ensures that Light Mode remains unchanged by default.

## How  
- Defined a set of CSS custom properties (variables) for color palette (backgrounds, text, borders, hover states, etc.) for both light and dark themes.  
- Modified the base styles and component styles to reference these variables rather than hard-coded colors.  
- Added logic (e.g. in configuration or user settings) to switch between themes — updating a root class or toggling a theme attribute so CSS variables take effect accordingly.  
- Updated UI components and layout as needed to maintain readability and layout integrity under dark background (e.g. adjusting contrast, hover/focus states, backgrounds, shadows).  
- (Optional / if implemented) Persist user preference of theme (e.g. in local storage or config) so the selected mode sticks between sessions.

## Why  
- Many users prefer Dark Mode for comfort, especially when using the app in low-light or nighttime conditions — reduces eye strain.  
- Provides better usability and accessibility for users sensitive to bright themes or working long hours.  
- Adds theming support, making the UI more flexible and future-proof for additional themes or user-customizable styles.  
- Aligns with modern UX expectations; many tools and apps offer Dark Mode as a standard feature.

## Acceptance Criteria  
- [ ] A “Dark Mode” toggle or setting appears in the configuration/settings menu.  
- [ ] When Dark Mode is enabled, all major UI sections (sidebar, nav, cards/panels, tables/lists, forms, modals) render with dark backgrounds and correct text visibility (sufficient contrast, no unreadable text).  
- [ ] When toggling back to Light Mode, the UI returns to the original light theme exactly as before — no residual dark-mode styles leak.  
- [ ] The theme change applies globally (not only to a subset of pages/components).  
- [ ] The selection of theme persists across page reloads (or application restarts), if persistence implemented.  
- [ ] No visual regressions in layout, spacing, or functionality — UI components (buttons, inputs, hover/focus states, modals, dialogs) behave and render correctly in both themes.  
- [ ] Styles for any third-party or external UI components/widgets are reviewed to confirm they do not break in Dark Mode (or are gracefully handled/fallback if unsupported).  

Closes #46