### PR TITLE
feat: Add Sidebar “Help / Team” Section

### DIFF
--- a/frontend/src/__tests__/TeamModal.test.tsx
+++ b/frontend/src/__tests__/TeamModal.test.tsx
@@ -128,4 +128,3 @@ describe('TeamModal', () => {
     expect(workerBadges).toHaveLength(2);
   });
 });
-

--- a/frontend/src/__tests__/TeamModal.test.tsx
+++ b/frontend/src/__tests__/TeamModal.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from '@testing-library/react';
+import TeamModal from '../components/TeamModal';
+import { User } from '../types/scheduler';
+
+// Mock UserAvatar component
+jest.mock('../components/UserAvatar', () => {
+  return function MockUserAvatar({ name }: { name: string }) {
+    return <div data-testid="user-avatar">{name}</div>;
+  };
+});
+
+describe('TeamModal', () => {
+  const mockOnHide = jest.fn();
+
+  const mockUsers: User[] = [
+    {
+      id: 1,
+      name: 'Admin User',
+      email: 'admin@colby.edu',
+      role: 'admin',
+      profile_picture_url: undefined,
+    },
+    {
+      id: 2,
+      name: 'Worker One',
+      email: 'worker1@colby.edu',
+      role: 'user',
+      class_year: 2025,
+      profile_picture_url: undefined,
+    },
+    {
+      id: 3,
+      name: 'Worker Two',
+      email: 'worker2@colby.edu',
+      role: 'user',
+      profile_picture_url: undefined,
+    },
+  ];
+
+  beforeEach(() => {
+    mockOnHide.mockClear();
+  });
+
+  it('renders modal when show is true', () => {
+    render(<TeamModal show={true} onHide={mockOnHide} users={mockUsers} />);
+
+    expect(screen.getByText('Team Members')).toBeInTheDocument();
+  });
+
+  it('does not render modal when show is false', () => {
+    render(<TeamModal show={false} onHide={mockOnHide} users={mockUsers} />);
+
+    expect(screen.queryByText('Team Members')).not.toBeInTheDocument();
+  });
+
+  it('displays loading spinner when loading is true', () => {
+    render(<TeamModal show={true} onHide={mockOnHide} users={[]} loading={true} />);
+
+    expect(screen.getByText('Team Members')).toBeInTheDocument();
+    // Should show spinner, not user lists
+    expect(screen.queryByText('Administrators')).not.toBeInTheDocument();
+  });
+
+  it('displays administrators section with correct count', () => {
+    render(<TeamModal show={true} onHide={mockOnHide} users={mockUsers} />);
+
+    expect(screen.getByText('Administrators')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument(); // 1 admin
+  });
+
+  it('displays workers section with correct count', () => {
+    render(<TeamModal show={true} onHide={mockOnHide} users={mockUsers} />);
+
+    expect(screen.getByText('Workers')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument(); // 2 workers
+  });
+
+  it('displays admin user details', () => {
+    render(<TeamModal show={true} onHide={mockOnHide} users={mockUsers} />);
+
+    // Name appears twice (avatar mock and display), so use getAllByText
+    expect(screen.getAllByText('Admin User').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('admin@colby.edu')).toBeInTheDocument();
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+  });
+
+  it('displays worker user details', () => {
+    render(<TeamModal show={true} onHide={mockOnHide} users={mockUsers} />);
+
+    // Names appear twice (avatar mock and display), so use getAllByText
+    expect(screen.getAllByText('Worker One').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('worker1@colby.edu')).toBeInTheDocument();
+    expect(screen.getAllByText('Worker Two').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('worker2@colby.edu')).toBeInTheDocument();
+  });
+
+  it('displays class year for workers who have it', () => {
+    render(<TeamModal show={true} onHide={mockOnHide} users={mockUsers} />);
+
+    expect(screen.getByText(/Class of 2025/)).toBeInTheDocument();
+  });
+
+  it('shows empty state when no administrators', () => {
+    const workersOnly = mockUsers.filter((u) => u.role === 'user');
+    render(<TeamModal show={true} onHide={mockOnHide} users={workersOnly} />);
+
+    expect(screen.getByText('No administrators found')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no workers', () => {
+    const adminsOnly = mockUsers.filter((u) => u.role === 'admin');
+    render(<TeamModal show={true} onHide={mockOnHide} users={adminsOnly} />);
+
+    expect(screen.getByText('No workers found')).toBeInTheDocument();
+  });
+
+  it('renders user avatars for all users', () => {
+    render(<TeamModal show={true} onHide={mockOnHide} users={mockUsers} />);
+
+    const avatars = screen.getAllByTestId('user-avatar');
+    expect(avatars).toHaveLength(3);
+  });
+
+  it('renders Worker badges for worker users', () => {
+    render(<TeamModal show={true} onHide={mockOnHide} users={mockUsers} />);
+
+    const workerBadges = screen.getAllByText('Worker');
+    expect(workerBadges).toHaveLength(2);
+  });
+});
+

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -4,6 +4,9 @@ import { Dropdown } from 'react-bootstrap';
 import { useAuth } from '../contexts/AuthContext';
 import UserAvatar from './UserAvatar';
 import ProfileEditModal from './ProfileEditModal';
+import TeamModal from './TeamModal';
+import api from '../services/api';
+import { User } from '../types/scheduler';
 
 interface AppShellProps {
   children: React.ReactNode;
@@ -241,6 +244,9 @@ const AppShell: React.FC<AppShellProps> = ({ children, pageTitle }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const [showProfileModal, setShowProfileModal] = useState(false);
+  const [showTeamModal, setShowTeamModal] = useState(false);
+  const [teamUsers, setTeamUsers] = useState<User[]>([]);
+  const [teamLoading, setTeamLoading] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(() => {
     // Check localStorage first, then system preference
     const stored = localStorage.getItem('theme');
@@ -274,6 +280,27 @@ const AppShell: React.FC<AppShellProps> = ({ children, pageTitle }) => {
 
   const handleProfileUpdate = (updatedUser: any) => {
     setUser(updatedUser);
+  };
+
+  const handleHelpCenter = () => {
+    const subject = encodeURIComponent('MuleScheduler Support Request');
+    const body = encodeURIComponent(
+      `Hello,\n\nI need help with MuleScheduler.\n\nName: ${user?.name || 'N/A'}\nEmail: ${user?.email || 'N/A'}\n\nIssue:\n\n`
+    );
+    window.location.href = `mailto:demo.admin@colby.edu?subject=${subject}&body=${body}`;
+  };
+
+  const handleTeamClick = async () => {
+    setTeamLoading(true);
+    setShowTeamModal(true);
+    try {
+      const response = await api.get('/users');
+      setTeamUsers(response.data);
+    } catch (err) {
+      console.error('Failed to load team:', err);
+    } finally {
+      setTeamLoading(false);
+    }
   };
 
   const adminNavItems = [
@@ -350,24 +377,14 @@ const AppShell: React.FC<AppShellProps> = ({ children, pageTitle }) => {
           <div className="ms-sidebar-section">
             <div className="ms-sidebar-section-label">Quick Info</div>
             <div className="ms-sidebar-quick-stats">
-              <div className="ms-sidebar-stat">
-                <span className="ms-sidebar-stat-icon">
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                  >
-                    <line x1="12" y1="20" x2="12" y2="10" />
-                    <line x1="18" y1="20" x2="18" y2="4" />
-                    <line x1="6" y1="20" x2="6" y2="16" />
-                  </svg>
-                </span>
-                <span className="ms-sidebar-stat-text">Dashboard</span>
-              </div>
-              <div className="ms-sidebar-stat">
+              <div
+                className="ms-sidebar-stat"
+                onClick={handleTeamClick}
+                style={{ cursor: 'pointer' }}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => e.key === 'Enter' && handleTeamClick()}
+              >
                 <span className="ms-sidebar-stat-icon">
                   <svg
                     width="16"
@@ -391,7 +408,7 @@ const AppShell: React.FC<AppShellProps> = ({ children, pageTitle }) => {
 
         {/* Bottom Items */}
         <div className="ms-sidebar-bottom-expanded">
-          <button className="ms-sidebar-nav-item-expanded help">
+          <button className="ms-sidebar-nav-item-expanded help" onClick={handleHelpCenter}>
             <span className="ms-sidebar-nav-icon">
               <Icons.Help />
             </span>
@@ -558,6 +575,14 @@ const AppShell: React.FC<AppShellProps> = ({ children, pageTitle }) => {
         onHide={() => setShowProfileModal(false)}
         user={user}
         onUpdate={handleProfileUpdate}
+      />
+
+      {/* Team Modal */}
+      <TeamModal
+        show={showTeamModal}
+        onHide={() => setShowTeamModal(false)}
+        users={teamUsers}
+        loading={teamLoading}
       />
     </div>
   );

--- a/frontend/src/components/TeamModal.tsx
+++ b/frontend/src/components/TeamModal.tsx
@@ -1,0 +1,337 @@
+import { Modal } from 'react-bootstrap';
+import { User } from '../types/scheduler';
+import UserAvatar from './UserAvatar';
+
+interface TeamModalProps {
+  show: boolean;
+  onHide: () => void;
+  users: User[];
+  loading?: boolean;
+}
+
+function TeamModal({ show, onHide, users, loading = false }: TeamModalProps) {
+  const admins = users.filter((u) => u.role === 'admin');
+  const workers = users.filter((u) => u.role === 'user');
+
+  return (
+    <Modal show={show} onHide={onHide} size="lg" centered>
+      <Modal.Header
+        closeButton
+        style={{
+          borderBottom: '1px solid var(--ms-border, #E5E7EB)',
+          background: 'var(--ms-card-bg, #ffffff)',
+        }}
+      >
+        <Modal.Title
+          style={{
+            fontWeight: 700,
+            color: 'var(--ms-text-primary, #111827)',
+            fontSize: '1.25rem',
+          }}
+        >
+          Team Members
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body
+        style={{
+          background: 'var(--ms-bg, #F8FAFC)',
+          padding: '24px',
+          maxHeight: '70vh',
+          overflowY: 'auto',
+        }}
+      >
+        {loading ? (
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              padding: '48px',
+            }}
+          >
+            <div className="ms-spinner" />
+          </div>
+        ) : (
+          <>
+            {/* Administrators Section */}
+            <div style={{ marginBottom: '24px' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '8px',
+                  marginBottom: '16px',
+                }}
+              >
+                <div
+                  style={{
+                    width: '32px',
+                    height: '32px',
+                    borderRadius: '8px',
+                    background: 'linear-gradient(135deg, #002169 0%, #1E40AF 100%)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="2"
+                  >
+                    <path d="M12 15l-2-2m0 0l2-2m-2 2h4m5 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    <circle cx="12" cy="8" r="3" />
+                  </svg>
+                </div>
+                <h5
+                  style={{
+                    margin: 0,
+                    fontWeight: 600,
+                    color: 'var(--ms-text-primary, #111827)',
+                    fontSize: '1rem',
+                  }}
+                >
+                  Administrators
+                </h5>
+                <span
+                  style={{
+                    background: 'var(--ms-primary, #002169)',
+                    color: 'white',
+                    fontSize: '0.75rem',
+                    fontWeight: 600,
+                    padding: '2px 10px',
+                    borderRadius: '12px',
+                  }}
+                >
+                  {admins.length}
+                </span>
+              </div>
+
+              <div
+                style={{
+                  display: 'grid',
+                  gap: '12px',
+                }}
+              >
+                {admins.length === 0 ? (
+                  <div
+                    style={{
+                      padding: '16px',
+                      background: 'var(--ms-card-bg, #ffffff)',
+                      borderRadius: '12px',
+                      color: 'var(--ms-text-muted, #6B7280)',
+                      textAlign: 'center',
+                    }}
+                  >
+                    No administrators found
+                  </div>
+                ) : (
+                  admins.map((admin) => (
+                    <div
+                      key={admin.id}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '16px',
+                        padding: '16px',
+                        background: 'var(--ms-card-bg, #ffffff)',
+                        borderRadius: '12px',
+                        border: '1px solid var(--ms-border, #E5E7EB)',
+                        transition: 'box-shadow 0.2s ease',
+                      }}
+                    >
+                      <UserAvatar
+                        name={admin.name}
+                        email={admin.email}
+                        userId={admin.id}
+                        profilePhotoUrl={admin.profile_picture_url || undefined}
+                        size="md"
+                      />
+                      <div style={{ flex: 1 }}>
+                        <div
+                          style={{
+                            fontWeight: 600,
+                            color: 'var(--ms-text-primary, #111827)',
+                            marginBottom: '2px',
+                          }}
+                        >
+                          {admin.name}
+                        </div>
+                        <div
+                          style={{
+                            fontSize: '0.85rem',
+                            color: 'var(--ms-text-muted, #6B7280)',
+                          }}
+                        >
+                          {admin.email}
+                        </div>
+                      </div>
+                      <span
+                        style={{
+                          background: 'linear-gradient(135deg, #002169 0%, #1E40AF 100%)',
+                          color: 'white',
+                          fontSize: '0.75rem',
+                          fontWeight: 600,
+                          padding: '4px 12px',
+                          borderRadius: '16px',
+                        }}
+                      >
+                        Admin
+                      </span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+
+            {/* Workers Section */}
+            <div>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '8px',
+                  marginBottom: '16px',
+                }}
+              >
+                <div
+                  style={{
+                    width: '32px',
+                    height: '32px',
+                    borderRadius: '8px',
+                    background: 'linear-gradient(135deg, #059669 0%, #10B981 100%)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="2"
+                  >
+                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                    <circle cx="9" cy="7" r="4" />
+                    <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+                    <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+                  </svg>
+                </div>
+                <h5
+                  style={{
+                    margin: 0,
+                    fontWeight: 600,
+                    color: 'var(--ms-text-primary, #111827)',
+                    fontSize: '1rem',
+                  }}
+                >
+                  Workers
+                </h5>
+                <span
+                  style={{
+                    background: '#059669',
+                    color: 'white',
+                    fontSize: '0.75rem',
+                    fontWeight: 600,
+                    padding: '2px 10px',
+                    borderRadius: '12px',
+                  }}
+                >
+                  {workers.length}
+                </span>
+              </div>
+
+              <div
+                style={{
+                  display: 'grid',
+                  gap: '12px',
+                }}
+              >
+                {workers.length === 0 ? (
+                  <div
+                    style={{
+                      padding: '16px',
+                      background: 'var(--ms-card-bg, #ffffff)',
+                      borderRadius: '12px',
+                      color: 'var(--ms-text-muted, #6B7280)',
+                      textAlign: 'center',
+                    }}
+                  >
+                    No workers found
+                  </div>
+                ) : (
+                  workers.map((worker) => (
+                    <div
+                      key={worker.id}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '16px',
+                        padding: '16px',
+                        background: 'var(--ms-card-bg, #ffffff)',
+                        borderRadius: '12px',
+                        border: '1px solid var(--ms-border, #E5E7EB)',
+                        transition: 'box-shadow 0.2s ease',
+                      }}
+                    >
+                      <UserAvatar
+                        name={worker.name}
+                        email={worker.email}
+                        userId={worker.id}
+                        profilePhotoUrl={worker.profile_picture_url || undefined}
+                        size="md"
+                      />
+                      <div style={{ flex: 1 }}>
+                        <div
+                          style={{
+                            fontWeight: 600,
+                            color: 'var(--ms-text-primary, #111827)',
+                            marginBottom: '2px',
+                          }}
+                        >
+                          {worker.name}
+                        </div>
+                        <div
+                          style={{
+                            fontSize: '0.85rem',
+                            color: 'var(--ms-text-muted, #6B7280)',
+                          }}
+                        >
+                          {worker.email}
+                          {worker.class_year && (
+                            <span style={{ marginLeft: '8px' }}>
+                              • Class of {worker.class_year}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <span
+                        style={{
+                          background: 'linear-gradient(135deg, #059669 0%, #10B981 100%)',
+                          color: 'white',
+                          fontSize: '0.75rem',
+                          fontWeight: 600,
+                          padding: '4px 12px',
+                          borderRadius: '16px',
+                        }}
+                      >
+                        Worker
+                      </span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          </>
+        )}
+      </Modal.Body>
+    </Modal>
+  );
+}
+
+export default TeamModal;


### PR DESCRIPTION
## What  
- Adds a new “Help / Team” section in the application sidebar.  
- The new section provides users with quick access to help docs, team info, and support contacts (or equivalent).  
- Integrates the sidebar item into existing navigation structure — visible consistently across appropriate pages.  

## How  
- Updated the sidebar component/template to include a new entry “Help / Team”.  
- Created or updated the UI for the Help / Team pane (or page), containing links to documentation, support contact info, and team member info (or placeholders).  
- Ensured the new section is styled appropriately and integrates with existing layout and navigation — including hover/active states, visibility across responsive breakpoints, and correct routing/navigation.  
- Updated any existing routing or menu configuration to handle the new sidebar item so that navigation works correctly.  

## Why  
- Improves usability by giving users a dedicated, easily accessible place for help resources and team/support information.  
- Reduces friction for new or existing users seeking documentation or support, or trying to contact the team — increasing overall user satisfaction.  
- Helps centralize support and team-related information, making the UI more organized and maintainable.  

## Acceptance Criteria  
- [ ] The sidebar always displays a “Help / Team” entry (on relevant pages/views).  
- [ ] Clicking “Help / Team” opens the appropriate pane or page containing help docs / support info / team info.  
- [ ] The Help / Team UI is styled consistently with the rest of the application (layout, spacing, theme, responsive behavior).  
- [ ] Navigation works correctly (no broken links, correct routing).  
- [ ] Existing sidebar items and navigation functionality remain unaffected.  
- [ ] (Optional / if applicable) Help / Team content is populated (or placeholders are clear), and documentation/contact info is accurate.  

Closes #48 